### PR TITLE
Query needs an append to where, not just a set where

### DIFF
--- a/arca-app/arca-dispatcher/src/main/java/io/pivotal/arca/dispatcher/Query.java
+++ b/arca-app/arca-dispatcher/src/main/java/io/pivotal/arca/dispatcher/Query.java
@@ -20,6 +20,8 @@ import android.net.Uri;
 import android.os.Parcel;
 import android.os.Parcelable;
 
+import io.pivotal.arca.utils.ArrayUtils;
+
 public class Query extends Request<Cursor> implements Parcelable {
 
 	private String[] mProjection;
@@ -62,6 +64,19 @@ public class Query extends Request<Cursor> implements Parcelable {
 	public void setWhere(final String whereClause, final String... whereArgs) {
 		mWhereClause = whereClause;
 		mWhereArgs = whereArgs;
+	}
+
+	public void addWhere(final String whereClause, final String... whereArgs) {
+		if (mWhereClause != null) {
+			mWhereClause = mWhereClause + " AND " + whereClause;
+		} else {
+			mWhereClause = whereClause;
+		}
+		if (mWhereArgs != null) {
+			mWhereArgs = ArrayUtils.append(mWhereArgs, whereArgs);
+		} else {
+			mWhereArgs = whereArgs;
+		}
 	}
 
 	public void setSortOrder(final String sortOrder) {

--- a/arca-app/arca-dispatcher/src/test/java/io/pivotal/arca/dispatcher/QueryTest.java
+++ b/arca-app/arca-dispatcher/src/test/java/io/pivotal/arca/dispatcher/QueryTest.java
@@ -64,4 +64,28 @@ public class QueryTest extends AndroidTestCase {
 
 		parcel.recycle();
 	}
+
+public void testQueryAddWhere() {
+	final Uri uri = Uri.parse("content://empty");
+	final Query request = new Query(uri);
+
+	final String where = "test = ?";
+	final String[] whereArgs = { "true" };
+	final String where2 = "test2 = ?";
+	final String[] whereArgs2 = { "false" };
+
+	assertEquals(null, request.getWhereArgs());
+	assertEquals(null, request.getWhereClause());
+
+	request.addWhere(where, whereArgs);
+
+	assertEquals("test = ?", request.getWhereArgs());
+	assertArrayEquals({ "true" }, request.getWhereClause());
+
+	request.addWhere(where, whereArgs);
+
+	assertEquals("test = ? AND test2 = ?", request.getWhereArgs());
+	assertArrayEquals({ "true", "false" }, request.getWhereClause());
+}
+
 }


### PR DESCRIPTION
If you have two different filters, it's nice to be able to write
```
if (x) {
  query.addWhere("field = ?", val);
}

if (y) {
  query.addWhere("field2 = ?", val2);
}
```

rather than the messy chain of nested ifs or getWhereArgs required to do this under the old system.
