### PR TITLE
Added CursorAdapter for RecyclerView and associated Fragment

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -4,6 +4,7 @@ android:
     components:
         - build-tools-19.1.0
         - extra-android-support
+        - extra
     licenses:
         - android-sdk-license-5be876d5
         - android-sdk-license-598b93a6

--- a/arca-app/arca-adapters/build.gradle
+++ b/arca-app/arca-adapters/build.gradle
@@ -1,4 +1,4 @@
 dependencies {
     compile 'com.android.support:support-v4:21.0.3'
-    compile 'com.android.support:recyclerview-v7:22.2.0'
+    compile 'com.android.support:recyclerview-v7:22.2.1'
 }

--- a/arca-app/arca-adapters/build.gradle
+++ b/arca-app/arca-adapters/build.gradle
@@ -1,3 +1,4 @@
 dependencies {
     compile 'com.android.support:support-v4:21.0.3'
+    compile 'com.android.support:recyclerview-v7:22.2.0'
 }

--- a/arca-app/arca-adapters/src/main/java/io/pivotal/arca/adapters/RecyclerViewCursorAdapter.java
+++ b/arca-app/arca-adapters/src/main/java/io/pivotal/arca/adapters/RecyclerViewCursorAdapter.java
@@ -1,0 +1,149 @@
+/*
+ * Copyright (C) 2015 Pivotal Software, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.pivotal.arca.adapters;
+
+import android.content.Context;
+import android.database.Cursor;
+import android.support.v7.widget.RecyclerView;
+import android.util.SparseArray;
+import android.view.View;
+
+import java.util.Collection;
+
+public abstract class RecyclerViewCursorAdapter<VH extends RecyclerViewCursorAdapter.ArcaBindingRecyclerViewHolder> extends RecyclerView.Adapter<VH> {
+
+    protected boolean mDataValid;
+    protected Cursor mCursor;
+    protected int mRowIDColumn;
+
+    protected CursorAdapterHelper mCursorAdapterHelper;
+    protected Context mContext;
+    protected Collection<Binding> mBindings;
+
+    public RecyclerViewCursorAdapter(Context context, final Collection<Binding> bindings, Cursor cursor) {
+        this(context, bindings, cursor, null);
+    }
+
+    public RecyclerViewCursorAdapter(Context context, final Collection<Binding> bindings, Cursor cursor, ViewBinder viewBinder) {
+        super();
+        mContext = context;
+        mCursor = cursor;
+        mBindings = bindings;
+        mCursorAdapterHelper = new CursorAdapterHelper(bindings);
+
+        init(cursor);
+
+        if (viewBinder != null) {
+            mCursorAdapterHelper.setViewBinder(viewBinder);
+        }
+    }
+
+    void init(Cursor c) {
+        boolean cursorPresent = c != null;
+        mCursor = c;
+        mDataValid = cursorPresent;
+        mRowIDColumn = cursorPresent ? c.getColumnIndexOrThrow("_id") : -1;
+        setHasStableIds(true);
+    }
+
+    @Override
+    public void onBindViewHolder (VH holder, int position) {
+        if (!mDataValid) {
+            throw new IllegalStateException("This should only be called when the cursor is valid");
+        }
+        if (!mCursor.moveToPosition(position)) {
+            throw new IllegalStateException("Couldn't move cursor to position " + position);
+        }
+
+        onBindViewHolder(holder, mCursor, position);
+    }
+
+    public void onBindViewHolder (VH holder, Cursor cursor, int position) {
+        for (Binding binding : mBindings) {
+            View view = (View) holder.mViews.get(binding.getViewId());
+            mCursorAdapterHelper.bindView(view, mContext, cursor, getItemViewType(position));
+        }
+    }
+
+    public Cursor getCursor() {
+        return mCursor;
+    }
+
+    @Override
+    public int getItemCount () {
+        if (mDataValid && mCursor != null) {
+            return mCursor.getCount();
+        } else {
+            return 0;
+        }
+    }
+
+    @Override
+    public long getItemId (int position) {
+        if(hasStableIds() && mDataValid && mCursor != null){
+            if (mCursor.moveToPosition(position)) {
+                return mCursor.getLong(mRowIDColumn);
+            } else {
+                return RecyclerView.NO_ID;
+            }
+        } else {
+            return RecyclerView.NO_ID;
+        }
+    }
+
+    public void changeCursor(Cursor cursor) {
+        Cursor old = swapCursor(cursor);
+        if (old != null) {
+            old.close();
+        }
+    }
+
+    public Cursor swapCursor(Cursor newCursor) {
+        if (newCursor == mCursor) {
+            return null;
+        }
+        Cursor oldCursor = mCursor;
+        mCursor = newCursor;
+        if (newCursor != null) {
+            mRowIDColumn = newCursor.getColumnIndexOrThrow("_id");
+            mDataValid = true;
+            notifyDataSetChanged();
+        } else {
+            mRowIDColumn = -1;
+            mDataValid = false;
+            notifyItemRangeRemoved(0, getItemCount());
+        }
+        return oldCursor;
+    }
+
+    public boolean hasResults() {
+        final Cursor cursor = getCursor();
+        return cursor != null && cursor.getCount() > 0;
+    }
+
+    public class ArcaBindingRecyclerViewHolder extends RecyclerView.ViewHolder {
+        SparseArray<View> mViews;
+
+        public ArcaBindingRecyclerViewHolder(View itemView, Collection<Binding> bindings) {
+            super(itemView);
+            mViews = new SparseArray<>();
+
+            for (Binding binding : bindings) {
+                mViews.put(binding.getViewId(), itemView.findViewById(binding.getViewId()));
+            }
+        }
+    }
+}

--- a/arca-app/arca-adapters/src/test/java/io/pivotal/arca/adapters/RecyclerViewCursorAdapterTest.java
+++ b/arca-app/arca-adapters/src/test/java/io/pivotal/arca/adapters/RecyclerViewCursorAdapterTest.java
@@ -1,0 +1,141 @@
+/* 
+ * Copyright (C) 2015 Pivotal Software, Inc.
+ * 
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at 
+ * 
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ * 
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.pivotal.arca.adapters;
+
+import android.content.Context;
+import android.database.Cursor;
+import android.database.MatrixCursor;
+import android.test.AndroidTestCase;
+import android.view.View;
+import android.view.ViewGroup;
+import android.widget.FrameLayout;
+import android.widget.TextView;
+
+import junit.framework.Assert;
+
+import java.util.ArrayList;
+import java.util.Collection;
+
+public class RecyclerViewCursorAdapterTest extends AndroidTestCase {
+
+	public void testSupportCursorAdapterNullCursorHasNoResults() {
+		final TestRecyclerCursorAdapter adapter = new TestRecyclerCursorAdapter(getContext(), null, null);
+		assertFalse(adapter.hasResults());
+	}
+
+	public void testSupportCursorAdapterEmptyCursorHasNoResults() {
+		final MatrixCursor cursor = new MatrixCursor(new String[] { "_id" });
+		final TestRecyclerCursorAdapter adapter = new TestRecyclerCursorAdapter(getContext(), null, cursor);
+		assertFalse(adapter.hasResults());
+	}
+
+	public void testSupportCursorAdapterCursorHasResults() {
+		final Cursor cursor = createCursor(new String[] { "_id" });
+		final TestRecyclerCursorAdapter adapter = new TestRecyclerCursorAdapter(getContext(), null, cursor);
+		assertTrue(adapter.hasResults());
+	}
+
+	public void testItemCursorAdapterDefaultViewBinding() {
+		final TextView child1 = new TextView(getContext());
+		child1.setId(R.id.test_id_1);
+		final FrameLayout container = new FrameLayout(getContext());
+		container.addView(child1);
+		final String[] columns = new String[] { "_id" };
+		final Cursor cursor = createCursor(columns);
+		final Collection<Binding> bindings = createBindings(columns);
+		final TestRecyclerCursorAdapter adapter = new TestRecyclerCursorAdapter(getContext(), bindings, cursor);
+		TestRecyclerCursorAdapter.TestBindingViewHolder viewHolder = adapter.onCreateViewHolder(container, 0);
+		adapter.onBindViewHolder(viewHolder, 0);
+		assertEquals("default_test", child1.getText());
+	}
+
+	public void testItemCursorAdapterCustomViewBinding() {
+		final TextView child1 = new TextView(getContext());
+		child1.setId(R.id.test_id_1);
+		final FrameLayout container = new FrameLayout(getContext());
+		container.addView(child1);
+		final String[] columns = new String[] { "_id" };
+		final Cursor cursor = createCursor(columns);
+		final Collection<Binding> bindings = createBindings(columns);
+		final TestRecyclerCursorAdapter adapter = new TestRecyclerCursorAdapter(getContext(), bindings, cursor, new TestViewBinder());
+		TestRecyclerCursorAdapter.TestBindingViewHolder viewHolder = adapter.onCreateViewHolder(container, 0);
+		adapter.onBindViewHolder(viewHolder, 0);
+		assertEquals("custom_test", child1.getText());
+	}
+
+	public void testItemCursorAdapterCannotBindView() {
+		try {
+			final View child1 = new View(getContext());
+			child1.setId(R.id.test_id_1);
+			final FrameLayout container = new FrameLayout(getContext());
+			container.addView(child1);
+			final String[] columns = new String[] { "_id" };
+			final Cursor cursor = createCursor(columns);
+			final Collection<Binding> bindings = createBindings(columns);
+			final TestRecyclerCursorAdapter adapter = new TestRecyclerCursorAdapter(getContext(), bindings, cursor);
+			TestRecyclerCursorAdapter.TestBindingViewHolder viewHolder = adapter.onCreateViewHolder(container, 0);
+			adapter.onBindViewHolder(viewHolder, 0);
+			Assert.fail();
+		} catch (final IllegalStateException e) {
+			assertNotNull(e);
+		}
+	}
+
+	private static Collection<Binding> createBindings(final String[] columns) {
+		final Collection<Binding> bindings = new ArrayList<Binding>();
+		bindings.add(new Binding(R.id.test_id_1, columns[0]));
+		return bindings;
+	}
+
+	private static MatrixCursor createCursor(final String[] columns) {
+		final MatrixCursor cursor = new MatrixCursor(columns);
+		cursor.addRow(new String[] { "default_test" });
+		cursor.moveToFirst();
+		return cursor;
+	}
+
+	public class TestViewBinder implements ViewBinder {
+		@Override
+		public boolean setViewValue(final View view, final Cursor cursor, final Binding binding) {
+			((TextView) view).setText("custom_test");
+			return true;
+		}
+	}
+
+	public class TestRecyclerCursorAdapter extends RecyclerViewCursorAdapter<TestRecyclerCursorAdapter.TestBindingViewHolder> {
+
+		public TestRecyclerCursorAdapter(Context context, final Collection<Binding> bindings, Cursor cursor) {
+			super(context, bindings, cursor);
+		}
+
+		public TestRecyclerCursorAdapter(Context context, final Collection<Binding> bindings, Cursor cursor, ViewBinder viewBinder) {
+			super(context, bindings, cursor, viewBinder);
+		}
+
+		@Override
+		public TestBindingViewHolder onCreateViewHolder(ViewGroup parent, int viewType) {
+			return new TestBindingViewHolder(parent, mBindings);
+		}
+
+		class TestBindingViewHolder extends RecyclerViewCursorAdapter.ArcaBindingRecyclerViewHolder {
+
+			public TestBindingViewHolder(View itemView, Collection<Binding> bindings) {
+				super(itemView, bindings);
+			}
+		}
+	}
+
+}

--- a/arca-app/arca-fragments/src/main/java/io/pivotal/arca/fragments/ArcaItemRecyclerViewFragment.java
+++ b/arca-app/arca-fragments/src/main/java/io/pivotal/arca/fragments/ArcaItemRecyclerViewFragment.java
@@ -1,0 +1,60 @@
+/* 
+ * Copyright (C) 2015 Pivotal Software, Inc.
+ *
+ * Licensed under the Modified BSD License.
+ *
+ * All rights reserved.
+ */
+package io.pivotal.arca.fragments;
+
+import android.os.Bundle;
+import android.view.View;
+
+import io.pivotal.arca.adapters.RecyclerViewCursorAdapter;
+import io.pivotal.arca.dispatcher.QueryResult;
+
+public abstract class ArcaItemRecyclerViewFragment extends ArcaQuerySupportFragment {
+
+	public abstract RecyclerViewCursorAdapter onCreateAdapter(final View view, final Bundle savedInstanceState);
+
+	private RecyclerViewCursorAdapter mAdapter;
+
+	@Override
+	public void onViewCreated(final View view, final Bundle savedInstanceState) {
+		super.onViewCreated(view, savedInstanceState);
+
+		setupAdapterView(view, savedInstanceState);
+	}
+
+	private void setupAdapterView(final View view, final Bundle savedInstanceState) {
+		mAdapter = onCreateAdapter(view, savedInstanceState);
+	}
+
+	public RecyclerViewCursorAdapter getCursorAdapter() {
+		return mAdapter;
+	}
+
+	@Override
+	public final void onRequestComplete(final QueryResult result) {
+		if (result.hasError()) {
+			onContentError(result.getError());
+		} else {
+			getCursorAdapter().swapCursor(result.getResult());
+			onContentChanged(result);
+		}
+	}
+	@Override
+	public final void onRequestReset() {
+		getCursorAdapter().swapCursor(null);
+		onContentReset();
+	}
+
+	protected void onContentChanged(final QueryResult result) {
+	}
+
+	protected void onContentError(final io.pivotal.arca.dispatcher.Error error) {
+	}
+
+	protected void onContentReset() {
+	}
+}


### PR DESCRIPTION
I had to make the cursor abstract due to the nature of RecyclerViews in that it uses generics so allow subclassing of its inner ViewHolder class. If the adapter was not abstract, then we would be forced to use  RecyclerViewCursorAdapter's implementation of ViewHolder in our method overrides for onBindViewHolder() and onCreateViewHolder(). This would prevent us from using our own ViewHolder implementation.

\- extra
added in .travis.yml so that travis pulls down recyclerview properly
